### PR TITLE
fix: typo shuffle to shaffle

### DIFF
--- a/packages/cui/src/components/HighAndLowGame/models.ts
+++ b/packages/cui/src/components/HighAndLowGame/models.ts
@@ -26,7 +26,7 @@ export class HighAndLowGame {
   };
 
   constructor() {
-    this.deck = new FrenchSuited({ joker: 0, shaffle: true });
+    this.deck = new FrenchSuited({ joker: 0, shuffle: true });
     const [hold1, hold2] = this.deck.divide(2);
     this.holds = { 1: hold1, 2: hold2 };
   }

--- a/packages/french-suited-deck/src/deck.ts
+++ b/packages/french-suited-deck/src/deck.ts
@@ -9,7 +9,7 @@ import { Enumerate } from './types/util';
 const NUMBER_RANKS: ReadonlyArray<NumberRank> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13];
 
 export class FrenchSuited extends Deck<FrenchSuitedCard> {
-  constructor({ joker = 2, shaffle = false }: { joker?: Enumerate<3> | Color; shaffle?: boolean } = {}) {
+  constructor({ joker = 2, shuffle = false }: { joker?: Enumerate<3> | Color; shuffle?: boolean } = {}) {
     const cards: FrenchSuitedCard[] = [
       ...NUMBER_RANKS.map((rank) => new Spade(rank)),
       ...NUMBER_RANKS.map((rank) => new Club(rank)),
@@ -31,8 +31,8 @@ export class FrenchSuited extends Deck<FrenchSuitedCard> {
         break;
     }
     super(cards);
-    if (shaffle) {
-      this.shaffle();
+    if (shuffle) {
+      this.shuffle();
     }
   }
 }

--- a/packages/high-and-low-game/src/main.ts
+++ b/packages/high-and-low-game/src/main.ts
@@ -26,7 +26,7 @@ class HighAndLowGame {
   };
 
   constructor() {
-    this.deck = new FrenchSuited({ joker: 0, shaffle: true });
+    this.deck = new FrenchSuited({ joker: 0, shuffle: true });
     const [hold1, hold2] = this.deck.divide(2);
     this.holds = { 1: hold1, 2: hold2 };
   }

--- a/packages/playing-cards/src/models/__tests__/card-collection.spec.ts
+++ b/packages/playing-cards/src/models/__tests__/card-collection.spec.ts
@@ -155,9 +155,9 @@ describe('CardCollection', () => {
         expect(collection.slice()).toStrictEqual([c9, c8, c7, c6, c5, c4, c3, c2, c1, c0]);
       });
 
-      test('shaffle', () => {
+      test('shuffle', () => {
         collection = new CardCollection(cards);
-        collection.shaffle();
+        collection.shuffle();
         expect(collection.slice()).not.toStrictEqual(cards);
       });
     });

--- a/packages/playing-cards/src/models/card-collection.ts
+++ b/packages/playing-cards/src/models/card-collection.ts
@@ -106,7 +106,7 @@ export class CardCollection<C extends Card, E extends EventType = EventType> ext
    * @description
    * Fisher–Yatesアルゴリズム
    */
-  public shaffle(): void {
+  public shuffle(): void {
     for (let i = this.length - 1; i > 0; i--) {
       const r = Math.floor(Math.random() * (i + 1));
       const tmp = this.cards[i];


### PR DESCRIPTION
I'm afraid that it's a typo "shaffle", should be "shuffle".